### PR TITLE
Adds .dup property to Bitmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ void main()
     writeln("size before optimize = ", r7.sizeInBytes);
     r7.optimize();
     writeln("size after optimize = ", r7.sizeInBytes);
+    
+    // copy a bitmap (uses copy-on-write under the hood)
+    const r8 = r7.dup;
+    assert(r8 == r7);
 }
 ```
 

--- a/source/roaring/c.d
+++ b/source/roaring/c.d
@@ -233,3 +233,13 @@ roaring_uint32_iterator_t *roaring_create_iterator(const roaring_bitmap_t *ra);
 */
 @nogc
 void roaring_free_uint32_iterator(roaring_uint32_iterator_t *it);
+
+
+/**
+* Copies a  bitmap. This does memory allocation. The caller is responsible for
+* memory management.
+*
+*/
+@nogc
+roaring_bitmap_t *roaring_bitmap_copy(const roaring_bitmap_t *r);
+

--- a/source/roaring/roaring.d
+++ b/source/roaring/roaring.d
@@ -539,7 +539,23 @@ class Bitmap
         import std.conv : to;
         const bitmap = bitmapOf(5, 1, 2, 3, 5, 6);
         assert("{1, 2, 3, 5, 6}" == to!string(bitmap));
-    }    
+    }
+
+    Bitmap dup() const @property
+    {
+        return new Bitmap(roaring_bitmap_copy(bitmap));
+    }
+
+    unittest
+    {
+        const original = bitmapOf(1, 2, 3, 4);
+        auto copy = original.dup;
+
+        // Copy is editable whereas original is const
+        copy.add(5);
+        assert(5 !in original);
+        assert(5 in copy);
+    }
 
     private roaring_bitmap_t* bitmap;
 }
@@ -635,4 +651,8 @@ unittest
     writeln("size before optimize = ", r7.sizeInBytes);
     r7.optimize();
     writeln("size after optimize = ", r7.sizeInBytes);
+
+    // copy a bitmap (uses copy-on-write under the hood)
+    const r8 = r7.dup;
+    assert(r8 == r7);
 }


### PR DESCRIPTION
The bindings currently don't expose `roaring_bitmap_copy` in any way at the moment.  This PR adds the necessary function declaration to `c.d`, a `.dup` function to `Bitmap`, and the relevant unittests.