### PR TITLE
Adds the andnot operation with inplace variant

### DIFF
--- a/source/roaring/c.d
+++ b/source/roaring/c.d
@@ -96,6 +96,20 @@ roaring_bitmap_t *roaring_bitmap_xor(const roaring_bitmap_t *x1, const roaring_b
 @nogc @safe
 void roaring_bitmap_xor_inplace(roaring_bitmap_t *x1,
                                 const roaring_bitmap_t *x2);
+/**
+ * Computes the  difference (andnot) between two bitmaps
+ * and returns new bitmap. The caller is responsible for memory management.
+ */
+roaring_bitmap_t *roaring_bitmap_andnot(const roaring_bitmap_t *x1,
+                                        const roaring_bitmap_t *x2);
+
+/**
+ * Inplace version of roaring_bitmap_andnot, modifies x1. x1 != x2.
+ *
+ */
+void roaring_bitmap_andnot_inplace(roaring_bitmap_t *x1,
+                                   const roaring_bitmap_t *x2);
+
 
 @nogc @safe
 bool roaring_bitmap_contains(const roaring_bitmap_t *r, uint32_t val) pure;

--- a/source/roaring/roaring.d
+++ b/source/roaring/roaring.d
@@ -411,6 +411,37 @@ class Bitmap
         assert(r1 == bitmapOf(1, 2, 3, 5, 7, 8));
     }
 
+    /**
+     * Computes the difference of this bitmap and `b`; that is returns the
+     *  elements of `this` that are not in `b`.
+     */
+    Bitmap andNot(const Bitmap b) const
+    {
+        return new Bitmap(roaring_bitmap_andnot(bitmap, b.bitmap));
+    }
+    unittest
+    {
+        const a = bitmapOf(1, 2, 4, 5);
+        const b = bitmapOf(2, 3, 5);
+        assert(a.andNot(b) == bitmapOf(1, 4));
+        assert(b.andNot(a) == bitmapOf(3));
+    }
+
+    /**
+     * Performs the andNot operation in place.
+     */
+    void andNotInPlace(const Bitmap b)
+    {
+        roaring_bitmap_andnot_inplace(bitmap, b.bitmap);
+    }
+    unittest
+    {
+        auto a = bitmapOf(1, 2, 4, 5);
+        const b = bitmapOf(2, 3, 5);
+        a.andNotInPlace(b);
+        assert(a == bitmapOf(1, 4));
+    }
+
     @nogc @safe
     bool opBinaryRight(const string op)(const uint x) const
     if (op == "in")


### PR DESCRIPTION
Apologies for the burst of PRs, I'm working on a project and keep finding functionality that I need that isn't currently in the bindings.

The `andnot` function doesn't map cleanly to a binary operator (I considered `-` but thought that might imply a symmetric set difference), so I've just called camel cased it.  This operation is necessary for any kind of index that wants to support the NOT operator.